### PR TITLE
Update README.md with information about BankID and Swish

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ vc.loadCheckout(publicToken: "<Your token>")
 present(vc, animated: true)
 ```
 
+### Swedish BankID and Swish
+
+In order to support Swedish BankID and Swish the app's `Info.plist` must contain `LSApplicationQueriesSchemes` with the following values:
+
+```
+...
+<key>LSApplicationQueriesSchemes</key>
+<array>
+    <string>bankid</string>
+    <string>swish</string>
+</array>
+...
+```
+
 ### Test data
 
 [Walley Checkout test data](https://dev.walleypay.com/docs/checkout/test-data)


### PR DESCRIPTION
It might be worth adding this information in the documentation. If these steps are not followed the error alert will pop up even though the apps are installed on the device. See [Apple's documentation](https://developer.apple.com/documentation/uikit/uiapplication/1622952-canopenurl) for more context.

It might also be worth considering to localise the error messages in the future.