### PR TITLE
Add internal parameter name for shouldOpenUrl

### DIFF
--- a/Sources/WalleyCheckout/WalleyCheckoutView.swift
+++ b/Sources/WalleyCheckout/WalleyCheckoutView.swift
@@ -12,11 +12,11 @@ public protocol WalleyCheckoutDelegate: AnyObject {
     /// Called when user taps on a link inside WalleyCheckout UI.
     ///
     /// - Returns: Return true if WalleyCheckout should use default web view presentation.
-    func walleyCheckoutView(_ walleyCheckoutView: WalleyCheckoutView, shouldOpenUrl: URL) -> Bool
+    func walleyCheckoutView(_ walleyCheckoutView: WalleyCheckoutView, shouldOpenUrl url: URL) -> Bool
 }
 
 extension WalleyCheckoutDelegate {
-    func walleyCheckoutView(_ walleyCheckoutView: WalleyCheckoutView, shouldOpenUrl: URL) -> Bool {
+    func walleyCheckoutView(_ walleyCheckoutView: WalleyCheckoutView, shouldOpenUrl url: URL) -> Bool {
         return true
     }
 }


### PR DESCRIPTION
It would be more natural for the consumer of this SDK to refer to the url with this internal naming instead.

This is a breaking change, but since we haven't versioned the SDK yet I think it would be ok to introduce this now.