### PR TITLE
Redirect handling

### DIFF
--- a/Sources/WalleyCheckout/WalleyCheckout.swift
+++ b/Sources/WalleyCheckout/WalleyCheckout.swift
@@ -15,6 +15,9 @@ final public class WalleyCheckout {
     }
     
     public static var environment: Environment = .production
+
+    /// The expected url to be redirected to once the purchase has been completed.
+    public static var redirectPageUrl: String?
     
     /// Generate walley checkout script tag using public token.
     ///

--- a/Sources/WalleyCheckout/WalleyCheckoutView.swift
+++ b/Sources/WalleyCheckout/WalleyCheckoutView.swift
@@ -19,6 +19,8 @@ public protocol WalleyCheckoutDelegate: AnyObject {
 }
 
 extension WalleyCheckoutDelegate {
+    func walleyCheckoutView(_ walleyCheckoutView: WalleyCheckoutView, didRedirectToPageUrl url: URL) {}
+
     func walleyCheckoutView(_ walleyCheckoutView: WalleyCheckoutView, shouldOpenUrl url: URL) -> Bool {
         return true
     }

--- a/Sources/WalleyCheckout/WalleyCheckoutView.swift
+++ b/Sources/WalleyCheckout/WalleyCheckoutView.swift
@@ -3,6 +3,9 @@ import WebKit
 
 public protocol WalleyCheckoutDelegate: AnyObject {
     
+    ///  Called when the view has been redirected to the url specified in WalleyCheckout.redirectPageUrl.
+    func walleyCheckoutView(_ walleyCheckoutView: WalleyCheckoutView, didRedirectToPageUrl url: URL)
+
     /// Recieve WalleyCheckout events
     func walleyCheckoutView(_ walleyCheckoutView: WalleyCheckoutView, didSendEvent event: WalleyCheckoutEvent)
     
@@ -155,6 +158,11 @@ class NavigationDelegate: NSObject, WKNavigationDelegate {
                 vc.loadUrl(url)
                 let nc = UINavigationController(rootViewController: vc)
                 checkoutView.parentViewController?.present(nc, animated: true)
+            } else if let url = navigationAction.request.url,
+                      let redirectPageUrlString = WalleyCheckout.redirectPageUrl,
+                      urlString.hasPrefix(redirectPageUrlString),
+                      let checkoutView = checkoutView {
+                checkoutView.delegate?.walleyCheckoutView(checkoutView, didRedirectToPageUrl: url)
             }
         }
         decisionHandler(.allow)


### PR DESCRIPTION
Exposes a way for the consumer of the SDK to get notified when the redirect url has been called.

This adds a new method to the WalleyCheckoutDelegate, but with a default implementation to make this PR a non-breaking change.