### PR TITLE
Prepend original user agent when setting  WalleyPaySDK/1.0

### DIFF
--- a/Sources/WalleyCheckout/WalleyCheckoutView.swift
+++ b/Sources/WalleyCheckout/WalleyCheckoutView.swift
@@ -62,7 +62,7 @@ final public class WalleyCheckoutView: UIView {
         ])
         setupWalleyEvents()
         setupHeightUpdateEvent()
-        webView.customUserAgent = "WalleyPaySDK/1.0 iOS/\(UIDevice.current.systemVersion)/\(UIDevice.current.model ?? "")"
+        webView.customUserAgent = "\(webView.customUserAgent) WalleyPaySDK/1.0 iOS/\(UIDevice.current.systemVersion)/\(UIDevice.current.model ?? "")"
         webView.scrollView.alwaysBounceVertical = false
         webView.navigationDelegate = navigationDelegate
         scriptMessageHandler.checkoutView = self


### PR DESCRIPTION
Due to a bug in the code of a vendor, the combination of /1 (as in /1.0) in the beginning of a user agent string caused an error.